### PR TITLE
Issue #9 - Open Source Guidelines for Gimlet

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,26 @@ helm install my-release onechart/onechart \
 ```
 
 See all [Examples](/examples/deploying-an-image)
+
+## Contribution Guidelines
+
+Thank you for your interest in contributing to the Gimlet project.
+
+Below are some of the guidelines and best practices for contributing to this repository:
+
+### Issues
+
+If you are running a fork of OneChart and would like to upstream a feature, please open a pull request for it.
+
+If you are planning to add a new feature to OneChart, please open an issue for it first. Helm charts are prone to having too many features, and OneChart want to keep the supported use-cases in-check. Proposed features have to be generally applicable, targeting newcomers to the Kubernetes ecosystem.
+
+### New Features / Components
+
+If you have any ideas on new features or want to improve the existing features, you can suggest it by opening a [GitHub issue](https://github.com/gimlet-io/onechart/issues/new). Make sure to include detailed information about the feature requests, use cases, and any other information that could be helpful.
+
+### Pull Request Process
+
+* Fork the repository.
+* Create a new branch and make your changes.
+* Open a pull request with detailed commit message and reference issue number if applicable.
+* A maintainer will review your pull request, and help you throughout the process.


### PR DESCRIPTION
This PR is referenced with issue #9 and as part of the issue, this PR adds some nice contributing guidelines to the first-time contributors. 
 
Reference: https://github.com/gimlet-io/gimlet-cli#contribution-guidelines