### PR TITLE
Generic sidecar support

### DIFF
--- a/charts/onechart/templates/deployment.yaml
+++ b/charts/onechart/templates/deployment.yaml
@@ -90,14 +90,16 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-        {{- if .Values.debugSidecarEnabled }}
-        - name: {{ template "robustName" .Release.Name }}-debug
+        {{- if .Values.sidecar }}
+        - name: {{ template "robustName" .Release.Name }}-sidecar
           securityContext: *securityContext
-          image: {{ .Values.debugSidecar.image }}
+          image: {{ .Values.sidecar.repository }}:{{ .Values.sidecar.tag }}
+          {{- if .Values.sidecar.command }}
           command:
-            - {{ .Values.debugSidecar.shell }}
+            - {{ .Values.sidecar.shell }}
             - -c
-            - {{ .Values.debugSidecar.command | quote }}
+            - {{ .Values.sidecar.command | quote }}
+          {{- end }}
           {{- if or (or (.Values.vars) (.Values.secretEnabled)) .Values.sealedSecrets }}
           envFrom: *envFrom
           {{- end }}

--- a/charts/onechart/tests/deployment_sidecar_test.yaml
+++ b/charts/onechart/tests/deployment_sidecar_test.yaml
@@ -3,9 +3,11 @@ templates:
   - deployment.yaml
   - configmap.yaml
 tests:
-  - it: Should add a debug sidecar
+  - it: Should inject a sidecar if one is specified
     set:
-      debugSidecarEnabled: true
+      sidecar:
+        repository: debian
+        tag: stable-slim
     asserts:
       - equal:
           path: spec.template.spec.containers[1].image

--- a/charts/onechart/tests/deployment_sidecar_test.yaml
+++ b/charts/onechart/tests/deployment_sidecar_test.yaml
@@ -12,3 +12,14 @@ tests:
       - equal:
           path: spec.template.spec.containers[1].image
           value: debian:stable-slim
+  - it: Should inject a debug sidecar with shell and command specified
+    set:
+      sidecar:
+        repository: debian
+        tag: stable-slim
+        shell: "/bin/bash"
+        command: "while true; do sleep 30; done;"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].image
+          value: debian:stable-slim

--- a/charts/onechart/values.yaml
+++ b/charts/onechart/values.yaml
@@ -44,12 +44,6 @@ secretEnabled: false
 
 shell: "/bin/sh"
 
-debugSidecarEnabled: false
-debugSidecar:
-  image: debian:stable-slim
-  shell: "/bin/bash"
-  command: "while true; do sleep 30; done;"
-
 podDisruptionBudgetEnabled: true
 spreadAcrossNodes: false
 

--- a/values.yaml
+++ b/values.yaml
@@ -9,3 +9,9 @@ fileSecrets:
         a
         multiline
         secret
+
+sidecar:
+  repository: debian
+  tag: stable-slim
+  shell: "/bin/bash"
+  command: "while true; do sleep 30; done;"


### PR DESCRIPTION
The `debugSidecar` field is deprecated. Instead, a generic `sidecar` field is introduced. This adds generic sidecar capabilities to OneChart.

The `debugSidecar` usecase still available with the following syntax:
```yaml
sidecar:
  repository: debian
  tag: stable-slim
  shell: "/bin/bash"
  command: "while true; do sleep 30; done;"
```


TODO:
- [ ] Update documentation
