### PR TITLE
Supporting a list of ports

### DIFF
--- a/charts/onechart/templates/deployment.yaml
+++ b/charts/onechart/templates/deployment.yaml
@@ -54,12 +54,16 @@ spec:
             {{- end }}
           {{- end }}
           ports:
-            {{- if not .Values.containerPortYaml }}
+            {{- if not .Values.ports }}
             - name: http
               containerPort: {{ .Values.containerPort }}
               protocol: TCP
             {{ else }}
-              {{- toYaml .Values.containerPortYaml | nindent 12 }}
+            {{- range .Values.ports }}
+            - name: {{ .name }}
+              containerPort: {{ .containerPort }}
+              protocol: TCP
+            {{- end }}
             {{- end }}
           {{- if .Values.probe.enabled }}
           readinessProbe:

--- a/charts/onechart/templates/service.yaml
+++ b/charts/onechart/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   type: {{ if .Values.nodePortEnabled }}NodePort{{ else }}ClusterIP{{ end }}
   ports:
+    {{- if not .Values.ports }}
     - port: {{ if .Values.svcPort }}{{ .Values.svcPort }}{{ else }}{{ .Values.containerPort }}{{ end }}
       targetPort: http
       protocol: TCP
@@ -15,5 +16,16 @@ spec:
       {{- if .Values.nodePort }}
       nodePort: {{ .Values.nodePort }}
       {{- end }}
+    {{ else }}
+    {{- range .Values.ports }}
+    - name: {{ .name }}
+      port: {{ if .svcPort }}{{ .svcPort }}{{ else }}{{ .containerPort }}{{ end }}
+      {{- if .nodePort }}
+      nodePort: {{ .nodePort }}
+      {{- end }}
+      targetPort: {{ .name }}
+      protocol: TCP
+    {{- end }}
+    {{- end }}
   selector:
     {{- include "helm-chart.selectorLabels" . | nindent 4 }}

--- a/charts/onechart/tests/deployment_ports_test.yaml
+++ b/charts/onechart/tests/deployment_ports_test.yaml
@@ -5,35 +5,26 @@ templates:
 tests:
   - it: Should set custom ports
     set:
-      containerPortYaml:
-        - port: 21
-          targetPort: ftp
-          protocol: TCP
+      ports:
+        - containerPort: 21
           name: ftp
-        - port: 3001
-          targetPort: passive-1
-          protocol: TCP
+        - containerPort: 3001
           name: passive-1
-        - port: 3002
-          targetPort: passive-2
-          protocol: TCP
+        - containerPort: 3002
           name: passive-2
     asserts:
       - equal:
           path: spec.template.spec.containers[0].ports
           value:
-            - port: 21
-              targetPort: ftp
+            - name: ftp
+              containerPort: 21
               protocol: TCP
-              name: ftp
-            - port: 3001
-              targetPort: passive-1
+            - name: passive-1
+              containerPort: 3001
               protocol: TCP
-              name: passive-1
-            - port: 3002
-              targetPort: passive-2
+            - name: passive-2
+              containerPort: 3002
               protocol: TCP
-              name: passive-2
   - it: Should set default port
     asserts:
       - equal:

--- a/charts/onechart/tests/service_ports_test.yaml
+++ b/charts/onechart/tests/service_ports_test.yaml
@@ -1,0 +1,66 @@
+suite: test deployment
+templates:
+  - service.yaml
+tests:
+  - it: Should set custom ports
+    set:
+      ports:
+        - containerPort: 21
+          name: ftp
+        - containerPort: 3001
+          name: passive-1
+        - containerPort: 3002
+          name: passive-2
+    asserts:
+      - equal:
+          path: spec.ports
+          value:
+            - name: ftp
+              port: 21
+              targetPort: ftp
+              protocol: TCP
+            - name: passive-1
+              port: 3001
+              targetPort: passive-1
+              protocol: TCP
+            - name: passive-2
+              port: 3002
+              targetPort: passive-2
+              protocol: TCP
+  - it: Should set custom svc port
+    set:
+      ports:
+        - containerPort: 2021
+          svcPort: 21
+          name: ftp
+        - containerPort: 3001
+          nodePort: 33001
+          name: passive-1
+        - containerPort: 3002
+          name: passive-2
+    asserts:
+      - equal:
+          path: spec.ports
+          value:
+            - name: ftp
+              port: 21
+              targetPort: ftp
+              protocol: TCP
+            - name: passive-1
+              port: 3001
+              nodePort: 33001
+              targetPort: passive-1
+              protocol: TCP
+            - name: passive-2
+              port: 3002
+              targetPort: passive-2
+              protocol: TCP
+  - it: Should set default port
+    asserts:
+      - equal:
+          path: spec.ports
+          value:
+            - port: 80
+              targetPort: http
+              protocol: TCP
+              name: http


### PR DESCRIPTION
With this PR merged:

- you can define a single port with `containerPort`, and the matching `svcPort` and `nodePort`.
- or define a list of ports with `containerPort`, and the matching `svcPort`s and `nodePort`s.
