### PR TITLE
Supporting multiple ingresses

### DIFF
--- a/charts/onechart/templates/ingress.yaml
+++ b/charts/onechart/templates/ingress.yaml
@@ -1,12 +1,7 @@
 {{- $labels := include "helm-chart.labels" . -}}
-
 {{- with .Values.ingress -}}
 {{- $robustName := include "robustName" $.Release.Name -}}
-{{- if semverCompare ">=1.14-0" $.Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
-{{- else -}}
-apiVersion: extensions/v1beta1
-{{- end }}
 kind: Ingress
 metadata:
   name: {{ $robustName }}

--- a/charts/onechart/templates/ingress.yaml
+++ b/charts/onechart/templates/ingress.yaml
@@ -1,29 +1,42 @@
-{{- $labels := include "helm-chart.labels" . -}}
-{{- with .Values.ingress -}}
-{{- $robustName := include "robustName" $.Release.Name -}}
+{{/* OneChart ingress snippet */}}
+{{- define "onechart.ingress" }}
+{{- $robustName := include "robustName" .root.Release.Name -}}
+---
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
+  {{- if .longName }}
+  name: {{ $robustName }}-{{ template "robustName" .ingress.host }}
+  {{- else }}
   name: {{ $robustName }}
-  namespace: {{ $.Release.Namespace }}
+  {{- end }}
+  namespace: {{ .root.Release.Namespace }}
   labels:
-    {{- $labels | nindent 4 }}
-  {{- with .annotations }}
+    {{- include "helm-chart.labels" .root | nindent 4 }}
+  {{- with .ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if default false .tlsEnabled }}
+  {{- if default false .ingress.tlsEnabled }}
   tls:
     - hosts:
-        - {{ template "robustName" .host | quote }}
+        - {{ template "robustName" .ingress.host | quote }}
       secretName: {{ printf "tls-%s" $robustName }}
   {{- end }}
   rules:
-    - host: {{ template "robustName" .host | quote }}
+    - host: {{ template "robustName" .ingress.host | quote }}
       http:
         paths:
-        - backend:
-            serviceName: {{ template "robustName" $.Release.Name }}
-            servicePort: {{ $.Values.containerPort }}
+          - backend:
+              serviceName: {{ $robustName }}
+              servicePort: {{ .root.Values.containerPort }}
+{{- end }}
+
+{{- with .Values.ingress }}
+  {{- template "onechart.ingress" (dict "root" $ "ingress" .) }}
+{{- end }}
+
+{{- range .Values.ingresses }}
+{{template "onechart.ingress" (dict "root" $ "ingress" . "longName" true) }}
 {{- end }}

--- a/charts/onechart/tests/ingress_domain_test.yaml
+++ b/charts/onechart/tests/ingress_domain_test.yaml
@@ -55,3 +55,31 @@ tests:
           path: metadata.annotations
           value:
             kubernetes.io/ingress.class: nginx
+  - it: Should generate multiple ingresses
+    set:
+      ingresses:
+      - host: chart-example.local
+        annotations:
+          kubernetes.io/ingress.class: nginx
+      - host: another.local
+        annotations:
+          kubernetes.io/ingress.class: nginx
+    asserts:
+      - hasDocuments:
+          count: 2
+  - it: Should generate multiple ingresses
+    set:
+      ingress:
+        host: chart-example.local
+        annotations:
+          kubernetes.io/ingress.class: nginx
+      ingresses:
+        - host: chart-example.local
+          annotations:
+            kubernetes.io/ingress.class: nginx
+        - host: another.local
+          annotations:
+            kubernetes.io/ingress.class: nginx
+    asserts:
+      - hasDocuments:
+          count: 3

--- a/values.yaml
+++ b/values.yaml
@@ -1,17 +1,11 @@
-fileSecrets:
-  - name: google-account-key
-    path: /google-account-key
-    secrets:
-      key.json: supersecret
-      another.json: |
-        this
-        is
-        a
-        multiline
-        secret
-
-sidecar:
-  repository: debian
-  tag: stable-slim
-  shell: "/bin/bash"
-  command: "while true; do sleep 30; done;"
+ingress:
+  host: chart-example.local
+  annotations:
+    kubernetes.io/ingress.class: nginx
+ingresses:
+  - host: chart-example.local
+    annotations:
+      kubernetes.io/ingress.class: nginx
+  - host: another.local
+    annotations:
+      kubernetes.io/ingress.class: nginx


### PR DESCRIPTION
Addressing: https://github.com/gimlet-io/onechart/issues/20

It is a common need to expose a service under multiple host names.
Typically in SRE operations.

This PR moves the ingress definition into a named template `onechart.ingress` and based on the `ingress` and `ingresses` chart values, it will be instantiated as many times as needed.

Examples:

- Single ingress, no changes
```
ingress:
  annotations:
    kubernetes.io/ingress.class: nginx
  host: chart-example.local
```

- Two ingresses created on different domains.
```
ingresses:
  - host: chart-example.local
    annotations:
      kubernetes.io/ingress.class: nginx
  - host: another.local
    annotations:
      kubernetes.io/ingress.class: nginx
```

