### PR TITLE
fix: Makes use of svcPort within ingress, when defined;

### DIFF
--- a/charts/onechart/templates/ingress.yaml
+++ b/charts/onechart/templates/ingress.yaml
@@ -38,7 +38,7 @@ spec:
         paths:
           - backend:
               serviceName: {{ $robustName }}
-              servicePort: {{ .root.Values.containerPort }}
+              servicePort: {{ if .root.Values.svcPort }}{{ .root.Values.svcPort }}{{ else }}{{ .root.Values.containerPort }}{{ end }}
 {{- end }}
 
 {{- with .Values.ingress }}

--- a/charts/onechart/tests/ingress_port_test.yaml
+++ b/charts/onechart/tests/ingress_port_test.yaml
@@ -1,0 +1,23 @@
+suite: test deployment
+templates:
+  - ingress.yaml
+tests:
+  - it: Should use container port
+    set:
+      ingress:
+        host: chart-example.local
+      containerPort: 1234
+    asserts:
+      - equal:
+          path: spec.rules[0].http.paths[0].backend.servicePort
+          value: 1234
+  - it: Should use service port
+    set:
+      ingress:
+        host: chart-example.local
+      svcPort: 1234
+      containerPort: 5678
+      asserts:
+        - equal:
+            path: spec.rules[0].http.paths[0].backend.servicePort
+            value: 1234


### PR DESCRIPTION
Makes use of svcPort, when present. Otherwise ingress would point to containerPort, which is not published via k8s service.