### PR TITLE
Add flag to ignore default resources for containers

### DIFF
--- a/charts/onechart/templates/deployment.yaml
+++ b/charts/onechart/templates/deployment.yaml
@@ -96,8 +96,10 @@ spec:
             {{- end }}
           {{- end }}
           {{- include "common.volumeMountsRef.tpl" . | nindent 10 }}
+          {{- if not .Values.resources.ignore }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
         {{- if .Values.sidecar }}
         - name: {{ template "robustName" .Release.Name }}-sidecar
           securityContext: *securityContext

--- a/charts/onechart/tests/deployment_resources_test.yaml
+++ b/charts/onechart/tests/deployment_resources_test.yaml
@@ -1,0 +1,18 @@
+suite: test deployment
+templates:
+  - deployment.yaml
+  - configmap.yaml
+tests:
+  - it: Should render resoucres if not ignored by default
+    set:
+      {}
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].resources
+  - it: Should ignore resources if ignore flag is set
+    set:
+      resources:
+        ignore: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].resources

--- a/charts/onechart/values.schema.json
+++ b/charts/onechart/values.schema.json
@@ -226,6 +226,16 @@
       ],
       "required": [],
       "properties": {
+        "ignore": {
+          "$id": "#/properties/resources/properties/ignore",
+          "type": "boolean",
+          "title": "Ignore",
+          "description": "If set to true, resource configuration will be ignored",
+          "default": false,
+          "examples": [
+            true
+          ]
+        },
         "requests": {
           "$id": "#/properties/resources/properties/requests",
           "type": "object",


### PR DESCRIPTION
### :sparkles: Summary of this change
I was expecting, when I don't define `resources` in my values.yaml, that the resource requests and limits are not rendered.
However, this is not true. Therefore I added a flag `ignore`.

The reason why I added an ignore flag rather than checking if `resources` is defined, is simply to not break the existing api.

### :technologist: Details
When `resources.ignore` is not set or `resources` are not defined in the `values.yaml`, the default values will be injected.
Exactly as before.

However, when setting `resources.ignore: true`, the default resources values won't be rendered.

### Why do we even need that?
For some containers, I simply want to give them the resources that are available, no matter what.
Also, when using this template on k3s, there are pod provisioning issues if resource requests and limits are given, the pod can't be scheduled due to insufficient resources.