### PR TITLE
Allow mounting of existing secrets

### DIFF
--- a/charts/common/templates/_volumeMountsRef.yaml
+++ b/charts/common/templates/_volumeMountsRef.yaml
@@ -1,5 +1,5 @@
 {{- define "common.volumeMountsRef.tpl" -}}
-{{- if or (or (.Values.volumes) (.Values.sealedFileSecrets)) .Values.fileSecrets }}
+{{- if or (or (or (.Values.volumes) (.Values.sealedFileSecrets)) .Values.fileSecrets) .Values.existingFileSecrets }}
 volumeMounts: &volumeMounts
 {{- range .Values.volumes }}
   - name: {{ .name }}
@@ -13,6 +13,14 @@ volumeMounts: &volumeMounts
 {{- range .Values.fileSecrets }}
   - name: {{ .name }}
     mountPath: {{ .path }}
+    readOnly: true
+{{- end }}
+{{- range .Values.existingFileSecrets }}
+  - name: {{ .name }}
+    mountPath: {{ .path }}
+    {{- if .subPath}}
+    subPath: {{ .subPath }}
+    {{- end }} 
     readOnly: true
 {{- end }}
 {{- end }}

--- a/charts/common/templates/_volumesRef.yaml
+++ b/charts/common/templates/_volumesRef.yaml
@@ -1,5 +1,5 @@
 {{- define "common.volumesRef.tpl" -}}
-{{- if or (or (.Values.volumes) (.Values.sealedFileSecrets)) .Values.fileSecrets }}
+{{- if or (or (or (.Values.volumes) (.Values.sealedFileSecrets)) .Values.fileSecrets) .Values.existingFileSecrets }}
 volumes:
   {{- range .Values.volumes }}
   - name: {{ .name }}
@@ -26,6 +26,11 @@ volumes:
       secretName: {{ printf "%s-%s" $.Release.Name .name }}
   {{- end }}
   {{- range .Values.fileSecrets }}
+  - name: {{ .name }}
+    secret:
+      secretName: {{ printf "%s-%s" $.Release.Name .name }}
+  {{- end }}
+  {{- range .Values.existingFileSecrets }}
   - name: {{ .name }}
     secret:
       secretName: {{ printf "%s-%s" $.Release.Name .name }}

--- a/charts/common/templates/_volumesRef.yaml
+++ b/charts/common/templates/_volumesRef.yaml
@@ -33,7 +33,7 @@ volumes:
   {{- range .Values.existingFileSecrets }}
   - name: {{ .name }}
     secret:
-      secretName: {{ printf "%s-%s" $.Release.Name .name }}
+      secretName: {{ .name }}
   {{- end }}
 {{- end }}
 {{- end -}}

--- a/charts/onechart/tests/deployment_existing_file_secrets_test.yaml
+++ b/charts/onechart/tests/deployment_existing_file_secrets_test.yaml
@@ -1,0 +1,44 @@
+suite: test deployment
+templates:
+  - deployment.yaml
+  - configmap.yaml
+  - pvc.yaml
+tests:
+  - it: Should mount volume
+    set:
+      existingFileSecrets:
+        - name: my-existing-secret
+          path: /config
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: my-existing-secret
+              mountPath: /config
+              readOnly: true
+  - it: Should mount volume with optional subPath
+    set:
+      existingFileSecrets:
+        - name: my-existing-secret
+          path: /config/config.yaml
+          subPath: config.yml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts
+          value:
+            - name: my-existing-secret
+              mountPath: /config/config.yaml
+              subPath: config.yml
+              readOnly: true
+  - it: Should reference volume
+    set:
+      existingFileSecrets:
+        - name: my-existing-secret
+          path: /config
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes
+          value:
+            - name: my-existing-secret
+              secret:
+                secretName: RELEASE-NAME-my-existing-secret

--- a/charts/onechart/tests/deployment_existing_file_secrets_test.yaml
+++ b/charts/onechart/tests/deployment_existing_file_secrets_test.yaml
@@ -41,4 +41,4 @@ tests:
           value:
             - name: my-existing-secret
               secret:
-                secretName: RELEASE-NAME-my-existing-secret
+                secretName: my-existing-secret

--- a/charts/onechart/values.schema.json
+++ b/charts/onechart/values.schema.json
@@ -702,7 +702,7 @@
                 "name": {
                   "type": "string",
                   "title": "Name",
-                  "description": "The name of th existing secret to moun",
+                  "description": "The name of the existing secret to mount",
                   "default": "data"
                 },
                 "path": {

--- a/charts/onechart/values.schema.json
+++ b/charts/onechart/values.schema.json
@@ -683,6 +683,48 @@
         }
       }
     },
+    "existingFileSecrets": {
+      "$id": "#/properties/existingFileSecrets",
+      "type": "array",
+      "title": "Existing file secrets",
+      "description": "Allows to mount existing secrets into a container",
+      "default": [],
+      "additionalItems": true,
+      "items": {
+        "$id": "#/properties/existingFileSecrets/items",
+        "type": "object",
+        "anyOf": [
+          {
+            "id": "#/properties/existingFileSecrets/oneOf/0",
+            "title": "existingFileSecrets",
+            "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "title": "Name",
+                  "description": "The name of th existing secret to moun",
+                  "default": "data"
+                },
+                "path": {
+                  "type": "string",
+                  "title": "Path",
+                  "description": "The mount path inside the container",
+                  "default": "/data"
+                },
+                "subPath": {
+                  "type": "string",
+                  "title": "SubPath",
+                  "description": "The optinal mount subpath inside the container, to only mount a specific file but not a complete directory.",
+                  "default": "config.yaml"
+                }
+              },
+              "required": [
+                "name", "path"
+              ]
+          }
+        ]
+      }
+    },
     "volumes": {
       "$id": "#/properties/volumes",
       "type": "array",


### PR DESCRIPTION
### :sparkles: Summary of this change
This PR implements the functionality to mount existing secets.
The fact why I actually need this is the not working sealedFileSecrets.

### :technologist: Details
Let's talk about the use-case in detail.
I have a very big config file encrypted via sealed secrets. In theory, I can mount `sealedFileSecrets` either from an input string or directly from a local file.
`sealedFileSecrets`, however can't read local files since the functionalitty is commented out. I tried a couple of hours to actually enable it, but whenever files are outside of the chart (which is always the case), helm can't read those.

So the only option that is left, is passing the file content via string into m values.yaml. This is not so nice if you've a huge encrypted file since it will blow up your values.yaml

Therefore, I tend to define the sealedSecret separatly and mount it via th new `existingFileSecret` option.

### FYI
I know I've opened quite a bit of PR's and likely more is comming.
I understand that you might want to keep this chart rather simple. I would like to use this chart as long as I can without moving to my own fork.

Would be really nice, to make this chart more and more flexbile for edge cases.