### PR TITLE
Dont generate claim for host path volumes

### DIFF
--- a/charts/common/templates/_pvc.yaml
+++ b/charts/common/templates/_pvc.yaml
@@ -1,6 +1,6 @@
 {{- define "common.pvc.tpl" -}}
 {{- range .Values.volumes }}
-{{- if not .existingClaim }}
+{{- if not (or .existingClaim .hostPath) }}
 {{- $robustName := include "common.robustName" $.Release.Name }}
 ---
 apiVersion: v1

--- a/charts/onechart/tests/pvc_test.yaml
+++ b/charts/onechart/tests/pvc_test.yaml
@@ -36,3 +36,13 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+  - it: Should not generate a claim when using host path
+    set:
+      volumes:
+        - name: data
+          path: /var/lib/1clickinfra/data
+          hostPath:
+            path: /data/test
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
It's me again :)
Found a bug when using host path volumes, for example:
```
volumes:
  - name: downloads
    path: /downloads
    hostPath:
      path: /data/downloads
```
Before my fix, this generated a PVC that was using the default claim and stuck in pending state.
For hostPath volumes, a PVC shouldn't be generated