### PR TITLE
Nginx Ingress Basic Auth

### DIFF
--- a/charts/onechart/templates/basic-auth.yaml
+++ b/charts/onechart/templates/basic-auth.yaml
@@ -1,0 +1,9 @@
+{{ if .Values.ingress }}{{ if .Values.ingress.nginxBasicAuth }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $resourceName }}-basic-auth
+  namespace: {{ .root.Release.Namespace }}
+data:
+  auth: {{ htpasswd .Values.ingress.nginxBasicAuth.user .Values.ingress.nginxBasicAuth.password  | b64enc }}
+{{ end }}{{ end }}

--- a/charts/onechart/templates/ingress.yaml
+++ b/charts/onechart/templates/ingress.yaml
@@ -13,8 +13,13 @@ metadata:
   namespace: {{ .root.Release.Namespace }}
   labels:
     {{- include "helm-chart.labels" .root | nindent 4 }}
-  {{- if or (or .root.Values.gitSha .ingress.annotations) .root.Values.gitRepository }}
+  {{- if or (or (or .root.Values.gitSha .ingress.nginxBasicAuth) .ingress.annotations) .root.Values.gitRepository }}
   annotations:
+    {{- if .ingress.nginxBasicAuth }}
+    nginx.ingress.kubernetes.io/auth-type: basic
+    nginx.ingress.kubernetes.io/auth-secret: {{ $resourceName }}-basic-auth
+    nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - basic'
+    {{- end }}
     {{- if .ingress.annotations }}
       {{- toYaml .ingress.annotations | nindent 4 }}
     {{- end }}

--- a/charts/onechart/tests/ingress_basic_auth_ing_test.yaml
+++ b/charts/onechart/tests/ingress_basic_auth_ing_test.yaml
@@ -1,0 +1,29 @@
+suite: test nginx basic auth ingress
+templates:
+  - ingress.yaml
+tests:
+  - it: Should set nginx specific annotations
+    set:
+      ingress:
+        host: chart-example.local
+        nginxBasicAuth:
+          user: admin1
+          password: secret1
+    asserts:
+      - equal:
+          path: metadata.annotations
+          value:
+            nginx.ingress.kubernetes.io/auth-type: basic
+            nginx.ingress.kubernetes.io/auth-secret: basic-auth
+            nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - basic'
+      - hasDocuments:
+          count: 1
+  - it: Should NOT set nginx specific annotations
+    set:
+      ingress:
+        host: chart-example.local
+    asserts:
+      - notExists:
+          path: metadata.annotations
+      - hasDocuments:
+          count: 1

--- a/charts/onechart/tests/ingress_basic_auth_secret_test.yaml
+++ b/charts/onechart/tests/ingress_basic_auth_secret_test.yaml
@@ -1,0 +1,26 @@
+suite: test nginx basic auth secret
+templates:
+  - basic-auth.yaml
+tests:
+  - it: Should set Ingress host name
+    set:
+      ingress:
+        host: chart-example.local
+        nginxBasicAuth:
+          user: admin1
+          password: secret1
+    asserts:
+      - hasDocuments:
+          count: 1
+      - exists:
+          path: data.auth
+
+  - it: Shouldnt generate extra secret
+    set:
+      ingresses:
+      - host: chart-example.local
+        annotations:
+          kubernetes.io/ingress.class: nginx
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/onechart/values.yaml
+++ b/charts/onechart/values.yaml
@@ -9,6 +9,9 @@ image:
 #   tlsEnabled: true
 #   annotations:
 #     cert-manager.io/cluster-issuer: letsencrypt-staging
+#   nginxBasicAuth:
+#     user: admin
+#     password: secret
 
 # vars:
 #   MY_VAR: "value"


### PR DESCRIPTION
Implement [nginx ingress basic-auth](https://kubernetes.github.io/ingress-nginx/examples/auth/basic/)

if you add:
```
ingress:
  host: secret.k8z.eu
  nginxBasicAuth:
    user: admin1
    password: secret1
```

You will get:
- a secret named: `basic-auth` with bcrypt encoded http password, using the [htpasswd sprig function](https://masterminds.github.io/sprig/crypto.html#htpasswd)
- 3 annotations on the ingress:
```
  annotations:
    nginx.ingress.kubernetes.io/auth-type: basic
    nginx.ingress.kubernetes.io/auth-secret: basic-auth
    nginx.ingress.kubernetes.io/auth-realm: 'Authentication Required - basic'
```