### PR TITLE
Publish OneChart to an OCI registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
         go-version: 1.16
 
@@ -31,7 +31,7 @@ jobs:
         helm plugin install https://github.com/helm-unittest/helm-unittest
 
     - name: Check out
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
       with:
         fetch-depth: 1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-go@v4
       with:
         go-version: 1.16
+        cache: false
 
     - name: Deps
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       uses: appany/helm-oci-chart-releaser@v0.4.1
       with:
         name: onechart
-        repository: ${{ github.repository }}
+        repository: helm
         tag: ${{ steps.versioning.outputs.tag_version }}
         registry: ghcr.io
         registry_username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,15 +78,18 @@ jobs:
         git config --global user.email "action@github.com"
         git config --global user.name "Github Action"
         git checkout master
+
         without_major_version=${CHART_VERSION#*.}
         without_patch_version=${without_major_version%.*}
         increased_minor_version=$(($without_patch_version + 1))
         major_version=${CHART_VERSION%%.*}
         increased_version="$major_version.$increased_minor_version.0"
         echo "The new version will be $increased_version"
+
         sed -i "s/version: $CHART_VERSION/version: $increased_version/" charts/onechart/Chart.yaml
         sed -i "s/version: $CHART_VERSION/version: $increased_version/" charts/cron-job/Chart.yaml
         sed -i "s/version: $CHART_VERSION/version: $increased_version/" charts/static-site/Chart.yaml
+
         git status
         git add .
         git commit -m "The next release version will be $increased_version"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       uses: appany/helm-oci-chart-releaser@v0.4.1
       with:
         name: onechart
-        repository: helm
+        repository: ${{ github.actor }}/helm
         tag: ${{ steps.versioning.outputs.tag_version }}
         registry: ghcr.io
         registry_username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,40 +67,12 @@ jobs:
         draft: false
         prerelease: false
 
-    - name: Publishing to the Helm repository
-      run: |
-        git config --global user.email "action@github.com"
-        git config --global user.name "Github Action"
-        git checkout master
-
-        make package
-
-        git add .
-        git commit -m "Publishing $TAG_VERSION to the Helm repository"
-        git push origin master
-      env:
-        TAG_VERSION: ${{ steps.versioning.outputs.tag_version }}
-
-    - name: Preparing the next release version
-      run: |
-        git config --global user.email "action@github.com"
-        git config --global user.name "Github Action"
-        git checkout master
-
-        without_major_version=${CHART_VERSION#*.}
-        without_patch_version=${without_major_version%.*}
-        increased_minor_version=$(($without_patch_version + 1))
-        major_version=${CHART_VERSION%%.*}
-        increased_version="$major_version.$increased_minor_version.0"
-        echo "The new version will be $increased_version"
-
-        sed -i "s/version: $CHART_VERSION/version: $increased_version/" charts/onechart/Chart.yaml
-        sed -i "s/version: $CHART_VERSION/version: $increased_version/" charts/cron-job/Chart.yaml
-        sed -i "s/version: $CHART_VERSION/version: $increased_version/" charts/static-site/Chart.yaml
-
-        git status
-        git add .
-        git commit -m "The next release version will be $increased_version"
-        git push origin master
-      env:
-        CHART_VERSION: ${{ steps.chart_version.outputs.chart_version }}
+    - name: Create and push chart to GHCR
+      uses: appany/helm-oci-chart-releaser@v0.4.1
+      with:
+        name: onechart
+        repository: ${{ github.repository }}
+        tag: ${{ steps.versioning.outputs.tag_version }}
+        registry: ghcr.io
+        registry_username: ${{ github.actor }}
+        registry_password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,7 @@ jobs:
     - name: Create a Release
       uses: elgohr/Github-Release-Action@v5
       env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         title: Release ${{ github.ref }}
     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,3 +72,24 @@ jobs:
         registry: ghcr.io
         registry_username: ${{ github.actor }}
         registry_password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Preparing the next release version
+      run: |
+        git config --global user.email "action@github.com"
+        git config --global user.name "Github Action"
+        git checkout master
+        without_major_version=${CHART_VERSION#*.}
+        without_patch_version=${without_major_version%.*}
+        increased_minor_version=$(($without_patch_version + 1))
+        major_version=${CHART_VERSION%%.*}
+        increased_version="$major_version.$increased_minor_version.0"
+        echo "The new version will be $increased_version"
+        sed -i "s/version: $CHART_VERSION/version: $increased_version/" charts/onechart/Chart.yaml
+        sed -i "s/version: $CHART_VERSION/version: $increased_version/" charts/cron-job/Chart.yaml
+        sed -i "s/version: $CHART_VERSION/version: $increased_version/" charts/static-site/Chart.yaml
+        git status
+        git add .
+        git commit -m "The next release version will be $increased_version"
+        git push origin master
+      env:
+        CHART_VERSION: ${{ steps.chart_version.outputs.chart_version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
       uses: appany/helm-oci-chart-releaser@v0.4.1
       with:
         name: onechart
-        repository: ${{ github.actor }}/helm
+        repository: ${{ github.actor }}
         tag: ${{ steps.versioning.outputs.tag_version }}
         registry: ghcr.io
         registry_username: ${{ github.actor }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
   
     - name: Checkout main
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         fetch-depth: 0
     
@@ -56,17 +56,13 @@ jobs:
         CHART_VERSION: ${{ steps.chart_version.outputs.chart_version }}
         CRON_JOB_CHART_VERSION: ${{ steps.chart_version.outputs.cron_job_chart_version }}
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
+    - name: Create a Release
+      uses: elgohr/Github-Release-Action@v5
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
       with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
-
+        title: Release ${{ github.ref }}
+    
     - name: Create and push chart to GHCR
       uses: appany/helm-oci-chart-releaser@v0.4.1
       with:

--- a/README.md
+++ b/README.md
@@ -8,16 +8,10 @@ https://gimlet.io/docs/onechart-reference
 
 ## Getting started
 
-Add the OneChart Helm repository:
-
-```bash
-helm repo add onechart https://chart.onechart.dev
-```
-
 Check the generated Kubernetes yaml:
 
 ```bash
-helm template my-release onechart/onechart \
+helm template my-release oci://ghcr.io/gimlet-io/onechart \
   --set image.repository=nginx \
   --set image.tag=1.19.3
 ```
@@ -25,7 +19,7 @@ helm template my-release onechart/onechart \
 Deploy with Helm:
 
 ```bash
-helm install my-release onechart/onechart \
+helm install my-release oci://ghcr.io/gimlet-io/onechart \
   --set image.repository=nginx \
   --set image.tag=1.19.3
 ```

--- a/website/docs/examples/custom-command.md
+++ b/website/docs/examples/custom-command.md
@@ -21,7 +21,7 @@ command: |
   while true; do date; sleep 2; done
 EOF
 
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```
 
 ### Using bash
@@ -37,7 +37,7 @@ command: |
 shell: "/bin/bash"
 EOF
 
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```
 
 ### Running a command in Alpine Linux
@@ -53,5 +53,5 @@ command: |
 shell: "/bin/ash"
 EOF
 
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```

--- a/website/docs/examples/debugSidecar.md
+++ b/website/docs/examples/debugSidecar.md
@@ -17,5 +17,5 @@ volumes:
 Check the Kubernetes manifest:
 
 ```bash
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```

--- a/website/docs/examples/deploying-a-private-image.md
+++ b/website/docs/examples/deploying-a-private-image.md
@@ -21,7 +21,7 @@ imagePullSecrets:
  - name: regcred
 EOF
 
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```
 
 !!! warning

--- a/website/docs/examples/deploying-an-image.md
+++ b/website/docs/examples/deploying-an-image.md
@@ -15,5 +15,5 @@ image:
   tag: 1.19.3
 EOF
 
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```

--- a/website/docs/examples/domain-names.md
+++ b/website/docs/examples/domain-names.md
@@ -25,7 +25,7 @@ ingress:
   host: my-release.mycompany.com
 EOF
 
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```
 
 !!! warning
@@ -48,5 +48,5 @@ ingress:
   tlsEnabled: true
 EOF
 
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```

--- a/website/docs/examples/environment-variables.md
+++ b/website/docs/examples/environment-variables.md
@@ -21,7 +21,7 @@ image:
 
 EOF
 
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```
 
 !!! note

--- a/website/docs/examples/feature-branch-deploys.md
+++ b/website/docs/examples/feature-branch-deploys.md
@@ -12,7 +12,7 @@ Release name is unique in Helm too, so it makes it a good tool to drive resource
 One good practice can be to add a `-$BRANCH` suffix to the feature branch instance:
 
 ```
-helm template my-release-my-branch onechart/onechart -f values.yaml
+helm template my-release-my-branch oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```
 
 ### Avoiding domain name collision
@@ -29,13 +29,13 @@ ingress:
     kubernetes.io/ingress.class: nginx
   host: my-release.mycompany.com
 
-helm template my-release-my-branch onechart/onechart -f values.yaml
+helm template my-release-my-branch oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```
 
 The `ingress.host` name should also be dynamic to avoid the collision:
 
 ```
-helm template my-release-my-branch onechart/onechart\
+helm template my-release-my-branch oci://ghcr.io/gimlet-io/onechart \
   -f values.yaml \
   --set ingress.host=my-release-my-branch.mycompany.com
 ```
@@ -45,7 +45,7 @@ helm template my-release-my-branch onechart/onechart\
 In CI the above command needs to be templated:
 
 ```
-helm template my-release-$BRANCH onechart/onechart\
+helm template my-release-$BRANCH oci://ghcr.io/gimlet-io/onechart \
   -f values.yaml \
   --set ingress.host=my-release-$BRANCH.mycompany.com
 ```

--- a/website/docs/examples/prometheus-monitoring-rules.md
+++ b/website/docs/examples/prometheus-monitoring-rules.md
@@ -23,5 +23,5 @@ prometheusRules:
 Check the Kubernetes manifest:
 
 ```bash
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```

--- a/website/docs/examples/secrets.md
+++ b/website/docs/examples/secrets.md
@@ -25,7 +25,7 @@ secret:
   enabled: true
 EOF
 
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```
 
 ### Using encrypted secret values

--- a/website/docs/examples/volumes.md
+++ b/website/docs/examples/volumes.md
@@ -27,7 +27,7 @@ volumes:
     storageClass: default
 EOF
 
-helm template my-release onechart/onechart -f values.yaml
+helm template my-release oci://ghcr.io/gimlet-io/onechart -f values.yaml
 ```
 
 !!! warning

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -1,14 +1,8 @@
 
-Add the OneChart Helm repository:
-
-```bash
-helm repo add onechart https://chart.onechart.dev
-```
-
 Check the generated Kubernetes yaml:
 
 ```bash
-helm template my-release onechart/onechart \
+helm template my-release oci://ghcr.io/gimlet-io/onechart \
   --set image.repository=nginx \
   --set image.tag=1.19.3
 ```
@@ -16,7 +10,7 @@ helm template my-release onechart/onechart \
 Deploy with Helm:
 
 ```bash
-helm install my-release onechart/onechart \
+helm install my-release oci://ghcr.io/gimlet-io/onechart \
   --set image.repository=nginx \
   --set image.tag=1.19.3
 ```


### PR DESCRIPTION
This PR contributes to https://github.com/gimlet-io/onechart/issues/78 by doing the following
- Bump all GitHub Actions to the latest version
- Replace the deprecated GitHub Action to the new one
- Change to push Helm Chart to GitHub OCI Artifact
- Update all documents to use OCI Artifact instead