### PR TITLE
Cloning private repos

### DIFF
--- a/charts/static-site/templates/deployment.yaml
+++ b/charts/static-site/templates/deployment.yaml
@@ -53,16 +53,16 @@ spec:
         - sh 
         - -c 
         - |
-           {{- if .Values.gitCloneUrlSecretName }}
-           git clone $gitCloneUrl &&
-           cd $(echo $gitCloneUrl | sed 's|.*/||' | cut -d "."  -f1) &&
-           {{- else }}
-           git clone {{ .Values.gitCloneUrl }} &&
-           cd {{ regexFind "([^\\/]+$)" .Values.gitCloneUrl | replace ".git" "" }} &&
-           {{- end }}
-           {{ .Values.buildScript | nindent 10}}
-           mkdir -p /usr/share/nginx/html &&
-           cp -r ./{{ .Values.builtAssets }}. /usr/share/nginx/html
+          {{- if .Values.gitCloneUrlSecretName }}
+          git clone $gitCloneUrl &&
+          cd $(echo $gitCloneUrl | sed 's|.*/||' | cut -d "."  -f1) &&
+          {{- else }}
+          git clone {{ .Values.gitCloneUrl }} &&
+          cd {{ regexFind "([^\\/]+$)" .Values.gitCloneUrl | replace ".git" "" }} &&
+          {{- end }}
+          {{ .Values.buildScript | nindent 10}}
+          mkdir -p /usr/share/nginx/html &&
+          cp -r ./{{ .Values.builtAssets }}. /usr/share/nginx/html
         {{- end }}
         volumeMounts:
         - name: static-files

--- a/charts/static-site/templates/deployment.yaml
+++ b/charts/static-site/templates/deployment.yaml
@@ -36,27 +36,37 @@ spec:
       serviceAccountName: {{ .Values.serviceAccount }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }} 
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       volumes:
       - name: static-files
-        emptyDir: {}  
+        emptyDir: {}
       initContainers:
       - name: init-con
         image: {{ .Values.buildImage }}
+        {{- if .Values.gitCloneUrlSecretName }}
+        envFrom:
+        - secretRef:
+            name: {{ .Values.gitCloneUrlSecretName }}
+        {{- end }}
         {{- if .Values.buildScript }}
         command:
         - sh 
         - -c 
         - |
-           git clone {{ .Values.gitCloneUrl}} &&
+           {{- if .Values.gitCloneUrlSecretName }}
+           git clone $gitCloneUrl &&
+           cd $(echo $gitCloneUrl | sed 's|.*/||' | cut -d "."  -f1) &&
+           {{- else }}
+           git clone {{ .Values.gitCloneUrl }} &&
            cd {{ regexFind "([^\\/]+$)" .Values.gitCloneUrl | replace ".git" "" }} &&
-           {{ .Values.buildScript | nindent 12}}
+           {{- end }}
+           {{ .Values.buildScript | nindent 10}}
            mkdir -p /usr/share/nginx/html &&
            cp -r ./{{ .Values.builtAssets }}. /usr/share/nginx/html
         {{- end }}
         volumeMounts:
         - name: static-files
-          mountPath: /usr/share/nginx/html   
+          mountPath: /usr/share/nginx/html
       containers:
         - name: {{ template "robustName" .Release.Name }}
           securityContext:

--- a/charts/static-site/values.yaml
+++ b/charts/static-site/values.yaml
@@ -18,6 +18,8 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
+gitCloneUrlSecretName: git-creds
+
 securityContext: 
   # capabilities:
   #   drop:


### PR DESCRIPTION
- Create a Kubernetes secret with a Github (fine-grained) personal access token (PAT)

```bash
export PAT=github_pat_xxxx
export GITHUB_URL_WITH_PAT=https://$PAT@github.com/laszlocph/reactjs-test-app-private.git

kubectl create secret generic git-creds --from-literal=gitCloneUrl=$GITHUB_URL_WITH_PAT
```

- Reference the secret to provide the github clone url

```diff
#values.yaml
- gitCloneUrl: https://github.com/laszlocph/reactjs-test-app.git
+ gitCloneUrlSecretName: git-creds
buildImage: "node:20.10-buster"
buildScript: npm install && npm run build
builtAssets: build/
```

```bash
helm template my-react-site onechart/static-site -f values.yaml | kubectl apply -f -
```