### PR TITLE
Feature - Added the option to add common labels for all resources

### DIFF
--- a/charts/cron-job/templates/_helpers.tpl
+++ b/charts/cron-job/templates/_helpers.tpl
@@ -35,6 +35,9 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "helm-chart.labels" -}}
+{{- range $key, $value := .Values.commonLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
 helm.sh/chart: {{ include "helm-chart.chart" . }}
 {{ include "helm-chart.selectorLabels" . }}
 {{- if .Chart.AppVersion }}

--- a/charts/cron-job/templates/_helpers.tpl
+++ b/charts/cron-job/templates/_helpers.tpl
@@ -35,15 +35,15 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "helm-chart.labels" -}}
-{{- range $key, $value := .Values.commonLabels }}
-{{ $key }}: {{ $value | quote }}
-{{- end }}
 helm.sh/chart: {{ include "helm-chart.chart" . }}
 {{ include "helm-chart.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- range $key, $value := .Values.commonLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/cron-job/values.yaml
+++ b/charts/cron-job/values.yaml
@@ -8,6 +8,10 @@ command: |
 overrideCommand: true
 shell: "/bin/sh"
 
+# commonLabels:
+#   label1: value1
+#   label2: value2
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/charts/namespaces/templates/_helpers.tpl
+++ b/charts/namespaces/templates/_helpers.tpl
@@ -41,6 +41,9 @@ helm.sh/chart: {{ include "helm-chart.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- range $key, $value := .Values.commonLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/onechart/templates/_helpers.tpl
+++ b/charts/onechart/templates/_helpers.tpl
@@ -41,6 +41,9 @@ helm.sh/chart: {{ include "helm-chart.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- range $key, $value := .Values.commonLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/onechart/values.yaml
+++ b/charts/onechart/values.yaml
@@ -16,6 +16,10 @@ image:
 # vars:
 #   MY_VAR: "value"
 
+# commonLabels:
+#   label1: value1
+#   label2: value2
+
 replicas: 1
 
 nameOverride: ""
@@ -80,3 +84,4 @@ monitor:
 
 container: {}
 podSpec: {}
+

--- a/charts/static-site/templates/_helpers.tpl
+++ b/charts/static-site/templates/_helpers.tpl
@@ -34,6 +34,9 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "staticSite.labels" -}}
+{{- range $key, $value := .Values.commonLabels }}
+{{ $key }}: {{ $value | quote }}
+{{- end }}
 helm.sh/chart: {{ include "staticSite.chart" . }}
 {{ include "staticSite.selectorLabels" . }}
 {{- if .Chart.AppVersion }}

--- a/values-cron-job.yaml
+++ b/values-cron-job.yaml
@@ -15,3 +15,7 @@ volumes:
     path: /data
     size: 10Gi
     storageClass: default
+
+commonLabels:
+  label1: value1
+  label2: value2

--- a/values.yaml
+++ b/values.yaml
@@ -26,3 +26,7 @@ probe:
 
 podSpec:
   hostNetwork: true
+
+commonLabels:
+  label1: value1
+  label2: value2


### PR DESCRIPTION
It is a common use-case that additional labels are required on the service.
In our case, each service must have the team label attached to it.
This change will enable setting common label for all resources under the chart.