### PR TITLE
feat(onechart): add optional api gateway http route resource

### DIFF
--- a/charts/onechart/Chart.yaml
+++ b/charts/onechart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.70.0
+version: 0.71.0
 
 dependencies:
   - name: common

--- a/charts/onechart/templates/http-route.yaml
+++ b/charts/onechart/templates/http-route.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.httpRoute.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ template "robustName" .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "helm-chart.labels" . | nindent 4 }}
+    {{- if .Values.httpRoute.annotations }}
+  annotations:
+    {{- toYaml .Values.httpRoute.annotations | nindent 4 -}}
+    {{- end }}
+
+spec:
+  parentRefs:
+    - name: {{ .Values.httpRoute.gatewayName }}
+      namespace: {{ .Values.httpRoute.gatewayNamespace }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: {{ .Values.httpRoute.pathPrefix }}
+      backendRefs:
+        - name: {{ template "robustName" .Release.Name }}
+          port: {{ if .Values.svcPort }}{{ .Values.svcPort }}{{ else }}{{ .Values.containerPort }}{{ end }}
+{{- end}}

--- a/charts/onechart/values.yaml
+++ b/charts/onechart/values.yaml
@@ -80,3 +80,6 @@ monitor:
 
 container: {}
 podSpec: {}
+
+httpRoute:
+  enabled: true


### PR DESCRIPTION
This adds a simple http route to a chosen gateway. 
I would expect in future people to expand the routing matches, but its fine for now and can be done in a backwards compatible way in future.