### PR TITLE
add restartPolicy to initContainers to support native sidecars

### DIFF
--- a/charts/common/templates/_podSpec.yaml
+++ b/charts/common/templates/_podSpec.yaml
@@ -15,6 +15,9 @@ initContainers:
   - name:  {{ .name }}
     image: "{{ .image }}:{{ .tag }}"
     imagePullPolicy: {{ .imagePullPolicy | default "IfNotPresent" }}
+    {{- if .restartPolicy }}
+    restartPolicy: "{{ .restartPolicy }}"
+    {{- end }}
     {{- include "common.envFromRef.tpl" $ | nindent 4 }}
     {{- if .command }}
     command:


### PR DESCRIPTION
As described here ([https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/](https://kubernetes.io/docs/concepts/workloads/pods/sidecar-containers/)) there is support for native sidecar containers by settings restartPolicy of initContainers to `Always`. This PR adds support to set this parameter.