### PR TITLE
add enabled to service

### DIFF
--- a/charts/onechart/templates/service.yaml
+++ b/charts/onechart/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if or (not (and (hasKey .Values "service") (hasKey .Values.service "enabled"))) .Values.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -84,3 +85,4 @@ spec:
     {{- end }}
   selector:
     {{- include "helm-chart.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/onechart/values.yaml
+++ b/charts/onechart/values.yaml
@@ -81,5 +81,5 @@ monitor:
 container: {}
 podSpec: {}
 
-service:
-  enabled: false
+# service:
+#   enabled: false

--- a/charts/onechart/values.yaml
+++ b/charts/onechart/values.yaml
@@ -80,3 +80,6 @@ monitor:
 
 container: {}
 podSpec: {}
+
+service:
+  enabled: false


### PR DESCRIPTION
Add enabled to service:

If **enabled** is defined and set to **false**, the service will not be created.
If **enabled** is either not defined or set to **true**, the service will be created.