### PR TITLE
Allow protocol to be set at the container level

### DIFF
--- a/charts/common/templates/_container.yaml
+++ b/charts/common/templates/_container.yaml
@@ -19,7 +19,7 @@ ports:
   {{- range .Values.ports }}
   - name: {{ .name }}
     containerPort: {{ .containerPort }}
-    protocol: TCP
+    protocol: {{ if .protocol }}{{ .protocol }}{{ else }}TCP{{ end }}
   {{- end }}
   {{- end }}
 {{- if .Values.probe.enabled }}


### PR DESCRIPTION
To accommodate traffic for different protocols at the container level, the protocol should be allowed to be set in the same way it's done at the service level, and default to TCP for backward compatibility.